### PR TITLE
Read woosmap key from sample json if present

### DIFF
--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -22,7 +22,7 @@
 {% block html %}{% endblock %}
 {% block api %}
     <script
-            src="https://sdk.woosmap.com/map/map.js?key={{ WOOSMAP_PUBLIC_API_KEY }}&callback={{ callback }}{% if libraries|length %}&libraries={{ libraries }}{% endif %}{% if language %}&language={{ language }}{% endif %}"
+            src="https://sdk.woosmap.com/map/map.js?key={% if key|length %}{{ key }}{% else %}{{ WOOSMAP_PUBLIC_API_KEY }}{% endif %}&callback={{ callback }}{% if libraries|length %}&libraries={{ libraries }}{% endif %}{% if language %}&language={{ language }}{% endif %}"
             defer></script>
 {% endblock %}
 </body>


### PR DESCRIPTION

## Closes #21 

## Describe your changes
- Include key in the sample's json file. Read key from here else pick up the default WOOSMAP_PUBLIC_KEY

## How to test
In your sample json file set the woosmap key you wish to override  to `key`  attribute
```javascript
{
  "title": "Add Map",
  "description": "A basic Woosmap Map sample centered on London",
  "callback": "initMap",
  "key": "woos_KEY_TO_OVERRIDE",
  "tag": "add_map",
  "name": "add-map",
  "pagination": {
    "data": "mode",
    "size": 1,
    "alias": "mode"
  },
  "permalink": "samples/{{ page.fileSlug }}/{{mode}}/{% if mode == 'jsfiddle' %}demo{% else %}index{% endif %}.{{ page.outputFileExtension }}"
}
``` 

## Checklist:
<!-- Please go through this list. Don't just tick the boxes, verify each one. -->

- [ ] My code follows the style guidelines for this repo
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings/errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I don't require ops changes for this PR to go to prod
- [ ] This change does not include a migration

## Comments
<!-- Any other comments... maybe a linked PR or note to remember something -->
