### PR TITLE
fix: transit-advanced - wrong duration value

### DIFF
--- a/samples/transit-advanced/index.ts
+++ b/samples/transit-advanced/index.ts
@@ -137,7 +137,8 @@ function createRoutesTable(response: woosmap.map.transit.TransitRouteResponse) {
     }
   }
 
-  function formatTime(minutes: number): string {
+  function formatTime(seconds: number): string {
+    const minutes = Math.round(seconds/60);
     if (minutes < 60) {
       return `${minutes}m`;
     } else {


### PR DESCRIPTION
Concerned demo: transit-advanced

Issue: duration value was interpreted like minutes instead of seconds

Fix: convert seconds into minutes