### PR TITLE
fix: Localities Nearby - add transit.station

### DIFF
--- a/samples/localities-nearby-poi/index.ts
+++ b/samples/localities-nearby-poi/index.ts
@@ -1,5 +1,8 @@
 // [START woosmap_localities_nearby_poi]
 const availableCategories = [
+  "transit.station",
+  "transit.station.airport",
+  "transit.station.rail",
   "business",
   "business.cinema",
   "business.theatre",


### PR DESCRIPTION
### Describe changes

```js
// [START woosmap_localities_nearby_poi]
const availableCategories = [
  "transit.station",  // NEW
  "transit.station.airport",  // NEW
  "transit.station.rail",  // NEW
  "business",
  "business.cinema",
  "business.theatre",
...
```