### PR TITLE
fix: convert departure time from milliseconds to seconds before requesting api

### DIFF
--- a/samples/directions-advanced/index.ts
+++ b/samples/directions-advanced/index.ts
@@ -453,7 +453,7 @@ function updateDepartureTime(): void {
     }
     const newDate = new Date(departureTimeElement.value);
     directionsRequest.departure_time = isValidDate(newDate)
-      ? newDate.getTime().toString()
+      ? Math.floor(newDate.getTime() / 1000).toString()
       : undefined;
     calculateDirections();
   });

--- a/samples/distance-matrix-advanced/index.ts
+++ b/samples/distance-matrix-advanced/index.ts
@@ -356,7 +356,9 @@ function updateDepartureTime(): void {
       datetimeRadioButton.checked = true;
     }
     const newDate = new Date(departureTimeElement.value);
-    distanceRequest.departureTime = isValidDate(newDate) ? newDate : undefined;
+    distanceRequest.departureTime = isValidDate(newDate)
+      ? Math.floor(newDate.getTime() / 1000).toString()
+      : undefined;
     calculateDistances();
   });
 }


### PR DESCRIPTION
…sting api

<!-- The title of the PR ↑↑↑ above should provide a general summary of what it is about. -->
<!-- Warning: any PR that has missing info is not ready to be reviewed. -->

## Issue
Closes #90 

## Describe your changes
- Convert `departure_time` from milliseconds to seconds

## How to test
Test on [PR-91](https://demo.woosmap.com/misc/js-samples-pr-deploy/pr-91/?sample=directions-advanced)

## Checklist:
<!-- Please go through this list. Don't just tick the boxes, verify each one. -->

- [x] My code follows the style guidelines for this repo
- [x] My code passes the SonarCloud check and does not add new code smells
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings/errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I don't require ops changes for this PR to go to prod
- [x] This change does not include a migration

### Documentation
<!-- Create issues to track any required documentation changes and include them here -->

### Libs/SDKs
<!-- Create issues to track any required library or SDK changes and include them here -->
