### PR TITLE
chore(deps): group Dependabot npm updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What
Add a catch-all `groups` block to `.github/dependabot.yml` so the weekly npm update produces **one combined PR** instead of one PR per dependency.

```yaml
    groups:
      dependencies:
        patterns:
          - "*"
```

## Why
The current config has no `groups`, so Dependabot opens a separate PR for every outdated dependency. Grouping all packages under a single `*` pattern collapses them into one weekly PR.

## Scope / notes
- Only the root `package.json` is watched (`directory: "/"`), so this is a single grouped PR. The nested `dist/samples/*/app/package.json` manifests are outside the configured directory and unaffected.
- Version updates only — Dependabot security-advisory PRs (if enabled) remain a separate stream by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)