### PR TITLE
fix: rotate API keys to new org and add address type to autocomplete samples

### DIFF
--- a/samples/datasets-api/index.njk
+++ b/samples/datasets-api/index.njk
@@ -12,9 +12,9 @@
                         <div class="od-container">
                             <span>Dataset</span>
                             <select id="dataset">
-                                <option value="07908ffb-14e8-46a1-a35e-5d5a305ca140">US National Risk Index</option>
-                                <option value="bd95d206-4822-4b78-9e82-ab724a888aeb">Worldwide Solar Potential</option>
-                                <option selected value="fd2732a6-714d-4894-98ef-c0c7744a399c">US - Seismic Hazard Map</option>
+                                <option value="c3262b13-4884-4761-bec4-dac28abf7137">US National Risk Index</option>
+                                <option value="223a1c86-39bc-4979-a53e-afef9b8d20fd">Worldwide Solar Potential</option>
+                                <option selected value="a01df3d6-fe7d-42df-8fee-9f31726a2641">US - Seismic Hazard Map</option>
                             </select>
                         </div>
                         <div class="od-container">

--- a/samples/datasets-api/index.ts
+++ b/samples/datasets-api/index.ts
@@ -15,7 +15,7 @@ let debouncedLocalitiesAutocomplete: (...args: any[]) => Promise<any>;
 let results: HTMLOListElement;
 let resetButton: HTMLButtonElement;
 
-const datasetId = "fd2732a6-714d-4894-98ef-c0c7744a399c"; //US - Seismic Hazard Map
+const datasetId = "a01df3d6-fe7d-42df-8fee-9f31726a2641"; //US - Seismic Hazard Map
 
 function initMap(): void {
   // [START woosmap_datasets_api_instantiate_map]

--- a/samples/datasets-api/index.ts
+++ b/samples/datasets-api/index.ts
@@ -224,6 +224,7 @@ async function updateDataset(datasetId: string) {
   await intersectCb(collection);
 }
 async function intersectCb(ev) {
+  if (!ev?.features?.[0]?.geometry) return;
   async function applyOperator(geometry, operator) {
     let response;
 

--- a/samples/env.11ty.js
+++ b/samples/env.11ty.js
@@ -12,7 +12,7 @@ module.exports = {
   },
 
   render({ sample }) {
-    let output = `VITE_WOOSMAP_PUBLIC_API_KEY=${sample.data.WOOSMAP_PUBLIC_API_KEY ? sample.data.WOOSMAP_PUBLIC_API_KEY : "woos-48c80350-88aa-333e-835a-07f4b658a9a4"}`;
+    let output = `VITE_WOOSMAP_PUBLIC_API_KEY=${sample.data.WOOSMAP_PUBLIC_API_KEY ? sample.data.WOOSMAP_PUBLIC_API_KEY : "woos-e1e5490b-19d1-34f8-9955-fd5cfc8c880f"}`;
     if (sample.data.GOOGLE_API_KEY) {
       output += `\nVITE_GOOGLE_API_KEY=${sample.data.GOOGLE_API_KEY}`;
     }

--- a/samples/localities-api-autocomplete/index.ts
+++ b/samples/localities-api-autocomplete/index.ts
@@ -134,7 +134,7 @@ function autocompleteAddress(
   const args = {
     key: woosmap_key,
     input,
-    types: "locality|postal_code",
+    types: "locality|postal_code|address",
   };
 
   if (components !== "") {

--- a/samples/localities-nearby-poi/index.ts
+++ b/samples/localities-nearby-poi/index.ts
@@ -140,7 +140,7 @@ function initMap() {
 
   autocompleteRequest = {
     input: "",
-    types: ["locality", "postal_code"],
+    types: ["locality", "postal_code", "address"],
   };
   nearbyRequest = {
     types: "point_of_interest",

--- a/samples/map-clustering-stores/map-clustering-stores.json
+++ b/samples/map-clustering-stores/map-clustering-stores.json
@@ -3,6 +3,7 @@
   "description": "This sample illustrates the usage of map clustering with Stores Search API",
   "category": "Markers",
   "callback": "initMap",
+  "WOOSMAP_PUBLIC_API_KEY": "woos-6a6b502e-5f28-3280-923f-b82ea0042a3a",
   "tag": "map_clustering_stores",
   "name": "map-clustering-stores",
   "pagination": {

--- a/samples/map-clustering-stores/map-clustering-stores.json
+++ b/samples/map-clustering-stores/map-clustering-stores.json
@@ -3,7 +3,6 @@
   "description": "This sample illustrates the usage of map clustering with Stores Search API",
   "category": "Markers",
   "callback": "initMap",
-  "WOOSMAP_PUBLIC_API_KEY": "woos-3cad58f4-0d94-3f95-8fa3-1f0dc035591c",
   "tag": "map_clustering_stores",
   "name": "map-clustering-stores",
   "pagination": {

--- a/samples/multisearch-map-advanced/multisearch-map-advanced.json
+++ b/samples/multisearch-map-advanced/multisearch-map-advanced.json
@@ -2,7 +2,6 @@
   "title": "MultiSearch Map Advanced",
   "description": "This example shows how to use the MultiSearch JS API and Map JS API to create a simple map with a search box. Parameters allows to limit the search to a specific country and to always search in stores attributes",
   "category": "Localities",
-  "WOOSMAP_PUBLIC_API_KEY": "woos-c562b391-2e0d-33f5-80c6-0cfd1e5bea09",
   "GOOGLE_API_KEY": "AIzaSyAAFBEYl6VnHSyllckphcRWzJlomsoXosA",
   "tag": "multisearch_map_advanced",
   "name": "multisearch-map-advanced",

--- a/samples/samples.11tydata.js
+++ b/samples/samples.11tydata.js
@@ -3,7 +3,7 @@ const _ = require("lodash");
 const data = {
   ..._.pick(
     {
-      WOOSMAP_PUBLIC_API_KEY: "woos-48c80350-88aa-333e-835a-07f4b658a9a4",
+      WOOSMAP_PUBLIC_API_KEY: "woos-e1e5490b-19d1-34f8-9955-fd5cfc8c880f",
       ...process.env,
     },
     ["WOOSMAP_PUBLIC_API_KEY"],

--- a/samples/store-locator-widget-enforce-accessibility/index.ts
+++ b/samples/store-locator-widget-enforce-accessibility/index.ts
@@ -265,7 +265,7 @@ const storeLocatorConfig = {
         {
           type: "bose_store",
           icon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/default.svg",
             scaledSize: {
               width: 24,
               height: 24,
@@ -276,7 +276,7 @@ const storeLocatorConfig = {
             },
           },
           selectedIcon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/selected.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/selected.svg",
             scaledSize: {
               width: 32,
               height: 32,
@@ -287,7 +287,7 @@ const storeLocatorConfig = {
             },
           },
           numberedIcon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/default.svg",
             scaledSize: {
               width: 32,
               height: 32,
@@ -301,7 +301,7 @@ const storeLocatorConfig = {
         {
           type: "bose_reseller",
           icon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default_reseller.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/default_reseller.svg",
             scaledSize: {
               width: 24,
               height: 24,
@@ -312,7 +312,7 @@ const storeLocatorConfig = {
             },
           },
           selectedIcon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/selected.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/selected.svg",
             scaledSize: {
               width: 32,
               height: 32,
@@ -323,7 +323,7 @@ const storeLocatorConfig = {
             },
           },
           numberedIcon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default_reseller.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/default_reseller.svg",
             scaledSize: {
               width: 32,
               height: 32,
@@ -337,7 +337,7 @@ const storeLocatorConfig = {
         {
           type: "professional_systems",
           icon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default_professional.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/default_professional.svg",
             scaledSize: {
               width: 24,
               height: 24,
@@ -348,7 +348,7 @@ const storeLocatorConfig = {
             },
           },
           selectedIcon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/selected.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/selected.svg",
             scaledSize: {
               width: 32,
               height: 32,
@@ -359,7 +359,7 @@ const storeLocatorConfig = {
             },
           },
           numberedIcon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default_professional.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/default_professional.svg",
             scaledSize: {
               width: 32,
               height: 32,
@@ -373,7 +373,7 @@ const storeLocatorConfig = {
         {
           type: "bose_excellence_centre",
           icon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default_excellence.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/default_excellence.svg",
             scaledSize: {
               width: 24,
               height: 24,
@@ -384,7 +384,7 @@ const storeLocatorConfig = {
             },
           },
           selectedIcon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/selected.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/selected.svg",
             scaledSize: {
               width: 32,
               height: 32,
@@ -395,7 +395,7 @@ const storeLocatorConfig = {
             },
           },
           numberedIcon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default_excellence.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/default_excellence.svg",
             scaledSize: {
               width: 32,
               height: 32,
@@ -409,7 +409,7 @@ const storeLocatorConfig = {
         {
           type: "bose_factory_store",
           icon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default_factory.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/default_factory.svg",
             scaledSize: {
               width: 24,
               height: 24,
@@ -420,7 +420,7 @@ const storeLocatorConfig = {
             },
           },
           selectedIcon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/selected.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/selected.svg",
             scaledSize: {
               width: 32,
               height: 32,
@@ -431,7 +431,7 @@ const storeLocatorConfig = {
             },
           },
           numberedIcon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default_factory.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/default_factory.svg",
             scaledSize: {
               width: 32,
               height: 32,
@@ -445,7 +445,7 @@ const storeLocatorConfig = {
       ],
       default: {
         icon: {
-          url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default.svg",
+          url: "https://images.woosmap.com/icons/bose_icons/default.svg",
           scaledSize: {
             width: 24,
             height: 24,
@@ -456,7 +456,7 @@ const storeLocatorConfig = {
           },
         },
         selectedIcon: {
-          url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/selected.svg",
+          url: "https://images.woosmap.com/icons/bose_icons/selected.svg",
           scaledSize: {
             width: 32,
             height: 32,
@@ -467,7 +467,7 @@ const storeLocatorConfig = {
           },
         },
         numberedIcon: {
-          url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default.svg",
+          url: "https://images.woosmap.com/icons/bose_icons/default.svg",
           scaledSize: {
             width: 32,
             height: 32,

--- a/samples/store-locator-widget-enforce-accessibility/store-locator-widget-enforce-accessibility.json
+++ b/samples/store-locator-widget-enforce-accessibility/store-locator-widget-enforce-accessibility.json
@@ -2,7 +2,7 @@
   "title": "Store Locator Widget - Enforce Accessibility",
   "description": "Woosmap Store Locator Widget displaying Bose stores all over the world. Enforcing accessibility features for better usability.",
   "category": "Store Locator Widget",
-  "WOOSMAP_PUBLIC_API_KEY": "woos-c562b391-2e0d-33f5-80c6-0cfd1e5bea09",
+  "WOOSMAP_PUBLIC_API_KEY": "woos-88403c6e-a493-337d-a620-7716f7aa6008",
   "tag": "store_locator_widget_enforce_accessibility",
   "name": "store-locator-widget-enforce-accessibility",
   "pagination": {

--- a/samples/store-locator-widget/index.ts
+++ b/samples/store-locator-widget/index.ts
@@ -264,7 +264,7 @@ const storeLocatorConfig = {
         {
           type: "bose_store",
           icon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/default.svg",
             scaledSize: {
               width: 24,
               height: 24,
@@ -275,7 +275,7 @@ const storeLocatorConfig = {
             },
           },
           selectedIcon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/selected.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/selected.svg",
             scaledSize: {
               width: 32,
               height: 32,
@@ -286,7 +286,7 @@ const storeLocatorConfig = {
             },
           },
           numberedIcon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/default.svg",
             scaledSize: {
               width: 32,
               height: 32,
@@ -300,7 +300,7 @@ const storeLocatorConfig = {
         {
           type: "bose_reseller",
           icon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default_reseller.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/default_reseller.svg",
             scaledSize: {
               width: 24,
               height: 24,
@@ -311,7 +311,7 @@ const storeLocatorConfig = {
             },
           },
           selectedIcon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/selected.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/selected.svg",
             scaledSize: {
               width: 32,
               height: 32,
@@ -322,7 +322,7 @@ const storeLocatorConfig = {
             },
           },
           numberedIcon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default_reseller.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/default_reseller.svg",
             scaledSize: {
               width: 32,
               height: 32,
@@ -336,7 +336,7 @@ const storeLocatorConfig = {
         {
           type: "professional_systems",
           icon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default_professional.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/default_professional.svg",
             scaledSize: {
               width: 24,
               height: 24,
@@ -347,7 +347,7 @@ const storeLocatorConfig = {
             },
           },
           selectedIcon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/selected.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/selected.svg",
             scaledSize: {
               width: 32,
               height: 32,
@@ -358,7 +358,7 @@ const storeLocatorConfig = {
             },
           },
           numberedIcon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default_professional.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/default_professional.svg",
             scaledSize: {
               width: 32,
               height: 32,
@@ -372,7 +372,7 @@ const storeLocatorConfig = {
         {
           type: "bose_excellence_centre",
           icon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default_excellence.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/default_excellence.svg",
             scaledSize: {
               width: 24,
               height: 24,
@@ -383,7 +383,7 @@ const storeLocatorConfig = {
             },
           },
           selectedIcon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/selected.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/selected.svg",
             scaledSize: {
               width: 32,
               height: 32,
@@ -394,7 +394,7 @@ const storeLocatorConfig = {
             },
           },
           numberedIcon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default_excellence.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/default_excellence.svg",
             scaledSize: {
               width: 32,
               height: 32,
@@ -408,7 +408,7 @@ const storeLocatorConfig = {
         {
           type: "bose_factory_store",
           icon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default_factory.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/default_factory.svg",
             scaledSize: {
               width: 24,
               height: 24,
@@ -419,7 +419,7 @@ const storeLocatorConfig = {
             },
           },
           selectedIcon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/selected.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/selected.svg",
             scaledSize: {
               width: 32,
               height: 32,
@@ -430,7 +430,7 @@ const storeLocatorConfig = {
             },
           },
           numberedIcon: {
-            url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default_factory.svg",
+            url: "https://images.woosmap.com/icons/bose_icons/default_factory.svg",
             scaledSize: {
               width: 32,
               height: 32,
@@ -444,7 +444,7 @@ const storeLocatorConfig = {
       ],
       default: {
         icon: {
-          url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default.svg",
+          url: "https://images.woosmap.com/icons/bose_icons/default.svg",
           scaledSize: {
             width: 24,
             height: 24,
@@ -455,7 +455,7 @@ const storeLocatorConfig = {
           },
         },
         selectedIcon: {
-          url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/selected.svg",
+          url: "https://images.woosmap.com/icons/bose_icons/selected.svg",
           scaledSize: {
             width: 32,
             height: 32,
@@ -466,7 +466,7 @@ const storeLocatorConfig = {
           },
         },
         numberedIcon: {
-          url: "https://webapp-conf.woosmap.com/woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae/default.svg",
+          url: "https://images.woosmap.com/icons/bose_icons/default.svg",
           scaledSize: {
             width: 32,
             height: 32,

--- a/samples/store-locator-widget/store-locator-widget.json
+++ b/samples/store-locator-widget/store-locator-widget.json
@@ -2,7 +2,7 @@
   "title": "Store Locator Widget",
   "description": "Woosmap Store Locator Widget displaying Bose stores all over the world ",
   "category": "Store Locator Widget",
-  "WOOSMAP_PUBLIC_API_KEY": "woos-c562b391-2e0d-33f5-80c6-0cfd1e5bea09",
+  "WOOSMAP_PUBLIC_API_KEY": "woos-88403c6e-a493-337d-a620-7716f7aa6008",
   "tag": "store_locator_widget",
   "name": "store-locator-widget",
   "pagination": {

--- a/samples/stores-list-sync-map/stores-list-sync-map.json
+++ b/samples/stores-list-sync-map/stores-list-sync-map.json
@@ -3,7 +3,7 @@
   "description": "Get all stores recursively. Synchronise the store list with the map display using map bounds and contains method",
   "category": "Services",
   "callback": "initMap",
-  "WOOSMAP_PUBLIC_API_KEY": "woos-5b16337d-8364-303a-854d-86f87b480aa5",
+  "WOOSMAP_PUBLIC_API_KEY": "woos-827f14de-6e1a-3149-bc9b-1709c39677b1",
   "tag": "stores_list_sync_map",
   "name": "stores-list-sync-map",
   "pagination": {

--- a/samples/stores-overlay-query-advanced/stores-overlay-query-advanced.json
+++ b/samples/stores-overlay-query-advanced/stores-overlay-query-advanced.json
@@ -3,7 +3,7 @@
   "description": "Filter the displayed stores based on a specific query using Query Helper",
   "category": "Stores Overlay",
   "callback": "initMap",
-  "WOOSMAP_PUBLIC_API_KEY": "woos-c562b391-2e0d-33f5-80c6-0cfd1e5bea09",
+  "WOOSMAP_PUBLIC_API_KEY": "woos-88403c6e-a493-337d-a620-7716f7aa6008",
   "libraries": [],
   "tag": "stores_overlay_query_advanced",
   "name": "stores-overlay-query-advanced",

--- a/samples/stores-search-autocomplete-api/stores-search-autocomplete-api.json
+++ b/samples/stores-search-autocomplete-api/stores-search-autocomplete-api.json
@@ -2,7 +2,6 @@
   "title": "Stores Search Autocomplete API",
   "description": "This example shows how to use the Stores Search Autocomplete API to search for stores based on their localized names.",
   "category": "Services",
-  "WOOSMAP_PUBLIC_API_KEY": "woos-0c78592f-13ea-362b-aa07-ba4ba9ea3dae",
   "tag": "stores_search_autocomplete_api",
   "name": "stores-search-autocomplete-api",
   "pagination": {


### PR DESCRIPTION
Closes #1610.

- Migrates samples to a new Woosmap project. The old org was grandfathered into the deprecated pre-details autocomplete, hiding the need to call `details` for geometry; the new key enforces current behavior.
- Adds `address` to `types` in `localities-api-autocomplete` and `localities-nearby-poi` where the type list was incomplete.
- Moves Store Locator marker icons from the project-scoped `webapp-conf.woosmap.com/woos-…/` path to `images.woosmap.com/icons/bose_icons/`.