### PR TITLE
Pin action versions and add Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,23 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    # Hold back brand-new releases: the hours after publication are the window
+    # in which a compromised package version is most likely to still be live.
+    cooldown:
+      default-days: 7
     groups:
       dependencies:
+        patterns:
+          - "*"
+
+  # Keeps the exact action versions pinned in .github/workflows from going stale.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
         patterns:
           - "*"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,16 +24,16 @@ jobs:
         shard: [1, 2, 3, 4, 5, 6, 7, 8]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.4.0
         with:
           lfs: true
-      - uses: actions/cache@v3
+      - uses: actions/cache@v3.5.0
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node
-      - uses: actions/cache@v3
+      - uses: actions/cache@v3.5.0
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-e2e
@@ -50,7 +50,7 @@ jobs:
         env:
           CI: true
       - name: Push test report to artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         if: failure()
         with:
           name: Test Results ${{ github.sha }}

--- a/.github/workflows/pr-to-s3.yml
+++ b/.github/workflows/pr-to-s3.yml
@@ -9,8 +9,8 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v4.4.0
+      - uses: actions/cache@v3.5.0
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -24,7 +24,7 @@ jobs:
           rm -rf dist/samples/**/package-lock.json
           rm -rf dist/samples/**/app/.gitignore
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v4.3.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/push-to-s3.yml
+++ b/.github/workflows/push-to-s3.yml
@@ -8,8 +8,8 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v4.4.0
+      - uses: actions/cache@v3.5.0
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -23,7 +23,7 @@ jobs:
           rm -rf dist/samples/**/package-lock.json
           rm -rf dist/samples/**/app/.gitignore
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v4.3.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,12 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.4.0
         with:
           token: ${{ secrets.WOOSMAP_GH_ACCESS_TOKEN }}
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4.4.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -42,7 +42,7 @@ jobs:
           GH_TOKEN: ${{ secrets.WOOSMAP_GH_ACCESS_TOKEN }}
 
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v6
+        uses: cycjimmy/semantic-release-action@v6.0.0
         with:
           extra_plugins: |
             @semantic-release/commit-analyzer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,8 @@ jobs:
       github.event.review.state == 'approved')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v4.4.0
+      - uses: actions/cache@v3.5.0
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/update-devdoc.yml
+++ b/.github/workflows/update-devdoc.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch Release Event
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v2.1.2
         with:
           token: ${{ secrets.WOOSMAP_GH_ACCESS_TOKEN }}
           repository: woosmap/developers.woosmap.com


### PR DESCRIPTION
Addresses all 16 high-severity Bastion SAST findings on this repo.

## Mutable action tags — 15 findings

CWE-1357 / CWE-353, OWASP A08. All 16 third-party `uses:` refs now name an exact patch version instead of a floating major:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` | `@v4.4.0` |
| `actions/cache` | `@v3` | `@v3.5.0` |
| `actions/setup-node` | `@v4` | `@v4.4.0` |
| `actions/upload-artifact` | `@v4` | `@v4.6.2` |
| `aws-actions/configure-aws-credentials` | `@v4` | `@v4.3.1` |
| `peter-evans/repository-dispatch` | `@v2` | `@v2.1.2` |
| `cycjimmy/semantic-release-action` | `@v6` | `@v6.0.0` |

Each version was resolved from what its floating major points at **right now**, so every job runs the same code as before — the refs just say so explicitly.

### The one that was genuinely bad

`cycjimmy/semantic-release-action@v6` — that repository has no `v6` *tag*. The ref was resolving to a **branch** named `v6`, i.e. a moving head equivalent to `@master`, on the action that cuts releases. Tag `v6.0.0` points at the same commit (`b12c8f60`) and is the latest release, so this is behaviour-identical while no longer tracking a branch.

Also worth flagging: `aws-actions/configure-aws-credentials` is the action that configures the credentials used to publish to S3, making it the highest-consequence pin in the repo.

### Why this doesn't clear the rule

Semgrep wants a 40-character commit SHA. Woosmap policy is exact version tags, not SHAs, so these are recorded as accepted risk in Bastion rather than fixed. The cooldown below covers the same threat from the other direction.

## Missing Dependabot cooldown — 1 finding

CWE-829. Added `cooldown: default-days: 7` to the npm entry, so freshly published releases wait a week before Dependabot proposes them — that publication window is when a compromised version is most likely to still be live.

Also added a `github-actions` ecosystem entry (weekly, same cooldown). Without it the exact pins above would never move; with it they get bumped on a reviewed PR. **This part is additive — happy to drop it if you'd rather not have action-bump PRs.**

## Risk and rollback

Only `uses:` refs and `dependabot.yml` changed; no workflow inputs, triggers, or job logic touched. All six workflow files and `dependabot.yml` verified as parseable YAML, and all seven version tags confirmed to resolve upstream. CI on this PR exercises checkout, cache, setup-node and upload-artifact directly; the S3 and release paths run post-merge. Rollback is `git revert` of this commit.

## Follow-up, not in this PR

`actions/cache@v3` is a superseded major and should move to v4. That's a behavioural change, so it belongs in its own PR rather than bundled with a pinning change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)